### PR TITLE
allow default handlers to be overridden

### DIFF
--- a/src/dispatchers/simple.coffee
+++ b/src/dispatchers/simple.coffee
@@ -3,11 +3,13 @@ Context = require("../context")
 
 module.exports = class SimpleDispatcher
 
-  constructor: (@service, @handlers) ->
-    for resource, actions of @service.default_handlers
-      handlers[resource] ||= {}
+  constructor: (@service, handlers) ->
+    @handlers = @service.default_handlers
+    
+    for resource, actions of handlers
+      @handlers[resource] ||= {}
       for name, handler of actions
-        handlers[resource][name] = handler
+        @handlers[resource][name] = handler
 
     for resource, definition of @service.resources
       for action, spec of definition.actions


### PR DESCRIPTION
I had a need to override the default CORS preflight headers provided by the default handler. I discovered that rather than providing defaults and allowing you to override them, patchboard was overriding my handlers with the defaults. This PR changes the behavior to start with the defaults and override with handlers that are passed in.
